### PR TITLE
fix silent syntax error

### DIFF
--- a/vendor/assets/javascripts/twitter/bootstrap/rails/confirm.coffee
+++ b/vendor/assets/javascripts/twitter/bootstrap/rails/confirm.coffee
@@ -7,13 +7,15 @@ $ ->
       proceed_class: "btn proceed btn-primary"
 
   TwitterBootstrapConfirmBox = (message, element, callback) ->
-    $(document.body).append($('
-      <div class="modal hide" id="confirmation_dialog">
-        <div class="modal-header"><button type="button" class="close" data-dismiss="modal">×</button><h3>...</h3></div>
-        <div class="modal-body"></div>
-        <div class="modal-footer"><a href="#" class="btn cancel" data-dismiss="modal">...</a><a href="#" class="btn proceed btn-primary">...</a></div>
-      </div>
-    '))
+    $(document.body).append(
+      $(
+        '<div class="modal hide" id="confirmation_dialog">
+          <div class="modal-header"><button type="button" class="close" data-dismiss="modal">×</button><h3>...</h3></div>
+          <div class="modal-body"></div>
+          <div class="modal-footer"><a href="#" class="btn cancel" data-dismiss="modal">...</a><a href="#" class="btn proceed btn-primary">...</a></div>
+        </div>'
+      )
+    )
 
     $("#confirmation_dialog .modal-body").html(message)
     $("#confirmation_dialog .modal-header h3").html(element.data("confirm-title") || $.fn.twitter_bootstrap_confirmbox.defaults.title || window.top.location.origin)


### PR DESCRIPTION
I don't know what this could be related to, but my first guesses are jquery and coffeescript. I'm running jquery 1.9.1 and coffee-rails 3.2.2 (coffee-script: 2.2.0, coffee-script-source: 1.4.0).

Anyhow, when I click a link with a `data-confirm`, no confirmation is opening and I'm being sent straight through to the link's href. Stepping through in the debugger, I can see that twitter-bootstrap-rails-confirm's compiled js is exploding here:

```
$('\
      <div class="modal hide" id="confirmation_dialog">\
        <div class="modal-header"><button type="button" class="close" data-dismiss="modal">×</button><h3>...</h3></div>\
        <div class="modal-body"></div>\
        <div class="modal-footer"><a href="#" class="btn cancel" data-dismiss="modal">...</a><a href="#" class="btn proceed btn-primary">...</a></div>\
      </div>\
    ')
```

with the error:

```
Error: Syntax error, unrecognized expression: <div class="modal hide" id="confirmation_dialog"> <div class="modal-header"><button type="button" class="close" data-dismiss="modal">×</button><h3>...</h3></div> <div class="modal-body"></div> <div class="modal-footer"><a href="#" class="btn cancel" data-dismiss="modal">...</a><a href="#" class="btn proceed btn-primary">...</a></div> </div>
```

I was able to resolve this by removing the leading and trailing carriage returns inside the string.
