### PR TITLE
click handler returns false

### DIFF
--- a/vendor/assets/javascripts/twitter/bootstrap/rails/confirm.coffee
+++ b/vendor/assets/javascripts/twitter/bootstrap/rails/confirm.coffee
@@ -25,7 +25,7 @@ TwitterBootstrapConfirmBox = (message, element, callback) ->
   $("#confirmation_dialog .proceed").click ->
     $("#confirmation_dialog").modal("hide").remove()
     callback()
-    true
+    false
 
   $("#confirmation_dialog .cancel").click ->
     $("#confirmation_dialog").modal("hide").remove()


### PR DESCRIPTION
If you have a link with `remote: true`, currently confirming it with twitter-bootstrap-rails-confirm causes a "#" to be added to the location. This is because the ".proceed" click handler returns true, allowing the default "a" click handler to fire, so the href "#" gets visited. Nothing breaks if we return false, however, because that's what the `callback()` method is for.

I've tested this on one of my apps, and it appears to work fine for both `remote: true` and `remote: false`.
