### PR TITLE
Add an option for including the fade class.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ This gem adds some javascript to change the default behaviour of data-confirm pr
 
 The normal confirm dialog shows a text with buttons 'ok' and 'cancel'. More information is needed here for a user to make the right decision. This gem therefore also adds:
 
+* data-confirm-fade (default: false)
 * data-confirm-title (default: window.top.location.origin)
 * data-confirm-cancel (default: 'cancel')
 * data-confirm-proceed (default: 'ok')
@@ -14,6 +15,7 @@ This behaviour is similar to that of a "regular" confirm box in ways that it use
 Changing all default values:
 
     $.fn.twitter_bootstrap_confirmbox.defaults = {
+        fade: false,
         title: null, // if title equals null window.top.location.origin is used
         cancel: "Cancel",
         proceed: "OK",
@@ -52,6 +54,7 @@ Next... nothing. There is nothing you need to do to get this working. A helper c
         :method => :delete,
         :class => "btn",
         :confirm => t('.destroy_confirm.body', :item => options[:item]),
+        "data-confirm-fade" => true,
         "data-confirm-title" => t('.destroy_confirm.title', :item => options[:item]),
         "data-confirm-cancel" => t('.destroy_confirm.cancel', :item => options[:item]),
         "data-confirm-proceed" => t('.destroy_confirm.proceed', :item => options[:item]),

--- a/vendor/assets/javascripts/twitter/bootstrap/rails/confirm.coffee
+++ b/vendor/assets/javascripts/twitter/bootstrap/rails/confirm.coffee
@@ -1,5 +1,6 @@
 $.fn.twitter_bootstrap_confirmbox =
   defaults:
+    fade: false
     title: null
     cancel: "Cancel"
     proceed: "OK"
@@ -16,19 +17,22 @@ TwitterBootstrapConfirmBox = (message, element, callback) ->
     )
   )
 
+  $("#confirmation_dialog").addClass("fade") if element.data("confirm-fade") || $.fn.twitter_bootstrap_confirmbox.defaults.fade
   $("#confirmation_dialog .modal-body").html(message)
   $("#confirmation_dialog .modal-header h3").html(element.data("confirm-title") || $.fn.twitter_bootstrap_confirmbox.defaults.title || window.top.location.origin)
   $("#confirmation_dialog .modal-footer .cancel").html(element.data("confirm-cancel") || $.fn.twitter_bootstrap_confirmbox.defaults.cancel)
   $("#confirmation_dialog .modal-footer .proceed").html(element.data("confirm-proceed") || $.fn.twitter_bootstrap_confirmbox.defaults.proceed).attr("class", $.fn.twitter_bootstrap_confirmbox.defaults.proceed_class).addClass(element.data("confirm-proceed-class"))
-  $("#confirmation_dialog").modal "show"
+  $("#confirmation_dialog").modal("show").on("hidden", ->
+    $(this).remove()
+  )
 
   $("#confirmation_dialog .proceed").click ->
-    $("#confirmation_dialog").modal("hide").remove()
+    $("#confirmation_dialog").modal("hide")
     callback()
     true
 
   $("#confirmation_dialog .cancel").click ->
-    $("#confirmation_dialog").modal("hide").remove()
+    $("#confirmation_dialog").modal("hide")
     false
 
 $.rails.allowAction = (element) ->


### PR DESCRIPTION
The fade class triggers animations that have the modal slide down and fade in when opened and slide up and fade out when closed. In order to properly handle this, removal of the modal is now performed in an event handler that listens for the `hidden` event fired by the modal. This also fixes an issue with the modal not being completely removed when
the backdrop is clicked.
