### PR TITLE
Prevent the default action on the modal's buttons.

### DIFF
--- a/vendor/assets/javascripts/twitter/bootstrap/rails/confirm.coffee
+++ b/vendor/assets/javascripts/twitter/bootstrap/rails/confirm.coffee
@@ -26,12 +26,14 @@ TwitterBootstrapConfirmBox = (message, element, callback) ->
     $(this).remove()
   )
 
-  $("#confirmation_dialog .proceed").click ->
+  $("#confirmation_dialog .proceed").click (event) ->
+    event.preventDefault()
     $("#confirmation_dialog").modal("hide")
     callback()
     true
 
-  $("#confirmation_dialog .cancel").click ->
+  $("#confirmation_dialog .cancel").click (event) ->
+    event.preventDefault()
     $("#confirmation_dialog").modal("hide")
     false
 


### PR DESCRIPTION
Adding `event.preventDefault()` prevents the browser from navigating to `#`, the href value assigned to the modal's buttons. It also instructs libraries like [Turbolinks](https://github.com/rails/turbolinks/) to ignore these button links.
