### PR TITLE
Create "click" event using an event constructor

### DIFF
--- a/vendor/assets/javascripts/twitter/bootstrap/rails/confirm.coffee
+++ b/vendor/assets/javascripts/twitter/bootstrap/rails/confirm.coffee
@@ -53,7 +53,7 @@ $.rails.allowAction = (element) ->
         
         if element.get(0).click
           element.get(0).click()
-        else if $.isFunction(document.createEvent)
+        else
           evt = new MouseEvents("click", {
             bubbles : true,
             cancelable : true,
@@ -71,8 +71,6 @@ $.rails.allowAction = (element) ->
             relatedTarget : document.body.parentNode
           })
           element.get(0).dispatchEvent(evt)
-        else
-          element.trigger "click"
 
         $.rails.allowAction = allowAction
   


### PR DESCRIPTION
The way the click event was being created is deprecated. An event constructor should be used instead:
https://developer.mozilla.org/en-US/docs/Web/Guide/DOM/Events/Creating_and_triggering_events

In addition using the event constructor fixes a scrolling bug where clicking the "OK" button in the
modal caused a scroll to the top of the page.
