### PR TITLE
Confirmbox defaults: Cancel button btn-default

### DIFF
--- a/vendor/assets/javascripts/twitter/bootstrap/rails/confirm.coffee
+++ b/vendor/assets/javascripts/twitter/bootstrap/rails/confirm.coffee
@@ -3,7 +3,7 @@ $.fn.twitter_bootstrap_confirmbox =
     fade: false
     title: null
     cancel: "Cancel"
-    cancel_class: "btn cancel"
+    cancel_class: "btn cancel btn-default"
     proceed: "OK"
     proceed_class: "btn proceed btn-primary"
 


### PR DESCRIPTION
The defaults for the confirmbox are missing the btn-default class for the cancel button. When no data-confirm-cancel-class is given, the default will be used.
