### PR TITLE
Avoid appending custom proceed class to btn-primary, refactored dialog JS

### DIFF
--- a/vendor/assets/javascripts/twitter/bootstrap/rails/confirm.coffee
+++ b/vendor/assets/javascripts/twitter/bootstrap/rails/confirm.coffee
@@ -33,7 +33,7 @@ TwitterBootstrapConfirmBox = (message, element, callback) ->
     .end()
 
     .find(".modal-footer")
-      .append( ->
+      .append(
         $("<a />", {href: "#", "data-dismiss": "modal"})
           .html(element.data("confirm-cancel") || $.fn.twitter_bootstrap_confirmbox.defaults.cancel)
           .addClass($.fn.twitter_bootstrap_confirmbox.defaults.cancel_class)


### PR DESCRIPTION
I largely refactored this to make a very basic change - to make it so that setting `data-confirm-proceed-class` overrides `btn-primary` as opposed to appending after it, as this doesn't style the element correctly, for example, a button with class `btn-primary btn-danger` can end up primary styled, they're not for use in conjunction.

Other than that, this should work exactly as it did before, just a hell of a lot easier to read (I hope!).

Also, saves re-querying for DOM elements you've already seen - lots and lots of selectors before - I expect this performs faster.
