### PR TITLE
When message is numerical, the call replace on message will cause a TypeError

### DIFF
--- a/vendor/assets/javascripts/twitter/bootstrap/rails/confirm.coffee
+++ b/vendor/assets/javascripts/twitter/bootstrap/rails/confirm.coffee
@@ -33,7 +33,7 @@ TwitterBootstrapConfirmBox = (message, element, callback) ->
     .end()
 
     .find(".modal-body")
-      .html(message.replace(/\n/g, "<br />"))
+      .html(message.toString().replace(/\n/g, "<br />"))
     .end()
 
     .find(".modal-footer")


### PR DESCRIPTION
When message is numerical, the call replace on message will cause a TypeError
For example:

```
link_to t("view.destroy"), path,
      method: :delete,
      class: 'btn btn-danger',
      :"data-confirm" => 42.0,
     ...
```

Will generate HTML like

```
<a class="btn btn-danger" data-confirm="42.0" data-method="delete" ...>...</a>
```

And will cause

```
Uncaught TypeError: Object 42.0 has no method 'replace' 
```
