### PR TITLE
Prevent dual modal

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Next... nothing. There is nothing you need to do to get this working. A helper c
 
 ### Unreleased
 
+* [(rvanlieshout)](https://github.com/rvanlieshout) Support for Bootstrap 3
 * [(rvanlieshout)](https://github.com/rvanlieshout) [Problems with using event constructors](https://github.com/bluerail/twitter-bootstrap-rails-confirm/issues/18)
 * [(stevelacey)](https://github.com/stevelacey) [Avoid appending custom proceed class to btn-primary, refactored dialog JS](https://github.com/bluerail/twitter-bootstrap-rails-confirm/pull/17)
 * [(zsy056)](https://github.com/zsy056) [When message is numerical, the call replace on message will cause a TypeError](https://github.com/bluerail/twitter-bootstrap-rails-confirm/pull/22)

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ The normal confirm dialog shows a text with buttons 'ok' and 'cancel'. More info
 * data-confirm-cancel-class (default: 'btn cancel')
 * data-confirm-proceed (default: 'ok')
 * data-confirm-proceed-class (default: 'btn-primary')
+* data-confirm-modal (default: false)
 
 This behaviour is similar to that of a "regular" confirm box in ways that it uses the same title and button labels. Defaults can be changed in two ways:
 
@@ -17,6 +18,7 @@ Changing all default values:
 
     $.fn.twitter_bootstrap_confirmbox.defaults = {
         fade: false,
+        modal: false,
         title: null, // if title equals null window.top.location.origin is used
         cancel: "Cancel",
         cancel_class: "btn cancel",
@@ -56,6 +58,7 @@ Next... nothing. There is nothing you need to do to get this working. A helper c
         :class => "btn",
         :confirm => t('.destroy_confirm.body', :item => options[:item]),
         "data-confirm-fade" => true,
+        "data-confirm-modal" => false,
         "data-confirm-title" => t('.destroy_confirm.title', :item => options[:item]),
         "data-confirm-cancel" => t('.destroy_confirm.cancel', :item => options[:item]),
         "data-confirm-cancel-class" => "btn-cancel"),

--- a/vendor/assets/javascripts/twitter/bootstrap/rails/confirm.coffee
+++ b/vendor/assets/javascripts/twitter/bootstrap/rails/confirm.coffee
@@ -6,6 +6,7 @@ $.fn.twitter_bootstrap_confirmbox =
     cancel: "Cancel"
     cancel_class: "btn cancel"
     fade: false
+    modal: true
 
 TwitterBootstrapConfirmBox = (message, element, callback) ->
   $dialog = $('
@@ -66,61 +67,68 @@ TwitterBootstrapConfirmBox = (message, element, callback) ->
     .appendTo(document.body)
 
 $.rails.allowAction = (element) ->
+  modal =  if element.data('confirm-modal')? then false else $.fn.twitter_bootstrap_confirmbox.defaults.modal
   message = element.data("confirm")
   answer = false
   return true unless message
 
   if $.rails.fire(element, "confirm")
-    TwitterBootstrapConfirmBox message, element, ->
-      if $.rails.fire(element, "confirm:complete", [answer])
-        allowAction = $.rails.allowAction
-
-        $.rails.allowAction = ->
-          true
-        
-        if element.get(0).click
-          element.get(0).click()
-          
-        else if Event?
-          evt = new Event("click", {
-            bubbles: true,
-            cancelable: true,
-            view: window,
-            detail: 0,
-            screenX: 0,
-            screenY: 0,
-            clientX: 0,
-            clientY: 0,
-            ctrlKey: false,
-            altKey: false,
-            shiftKey: false,
-            metaKey: false,
-            button: 0,
-            relatedTarget: document.body.parentNode
-          })
-          element.get(0).dispatchEvent(evt)
-
-        else if $.isFunction(document.createEvent)
-          evt = document.createEvent "MouseEvents"
-          evt.initMouseEvent(
-            "click",
-            true,   # e.bubbles,
-            true,   # e.cancelable,
-            window, # e.view,
-            0,      # e.detail,
-            0,      # e.screenX,
-            0,      # e.screenY,
-            0,      # e.clientX,
-            0,      # e.clientY,
-            false,  # e.ctrlKey,
-            false,  # e.altKey,
-            false,  # e.shiftKey,
-            false,  # e.metaKey,
-            0,      # e.button,
-            document.body.parentNode # e.relatedTarget
-          )
-          element.get(0).dispatchEvent(evt)
-
-        $.rails.allowAction = allowAction
+    if modal
+      TwitterBootstrapConfirmBox message, element, ->
+        if $.rails.fire(element, "confirm:complete", [answer])
+          allowAction = $.rails.allowAction
   
+          $.rails.allowAction = ->
+            true
+          
+          if element.get(0).click
+            element.get(0).click()
+            
+          else if Event?
+            evt = new Event("click", {
+              bubbles: true,
+              cancelable: true,
+              view: window,
+              detail: 0,
+              screenX: 0,
+              screenY: 0,
+              clientX: 0,
+              clientY: 0,
+              ctrlKey: false,
+              altKey: false,
+              shiftKey: false,
+              metaKey: false,
+              button: 0,
+              relatedTarget: document.body.parentNode
+            })
+            element.get(0).dispatchEvent(evt)
+  
+          else if $.isFunction(document.createEvent)
+            evt = document.createEvent "MouseEvents"
+            evt.initMouseEvent(
+              "click",
+              true,   # e.bubbles,
+              true,   # e.cancelable,
+              window, # e.view,
+              0,      # e.detail,
+              0,      # e.screenX,
+              0,      # e.screenY,
+              0,      # e.clientX,
+              0,      # e.clientY,
+              false,  # e.ctrlKey,
+              false,  # e.altKey,
+              false,  # e.shiftKey,
+              false,  # e.metaKey,
+              0,      # e.button,
+              document.body.parentNode # e.relatedTarget
+            )
+            element.get(0).dispatchEvent(evt)
+  
+          $.rails.allowAction = allowAction
+            $.rails.allowAction = allowAction
+    else
+      if $.rails.fire(element, 'confirm')
+        answer = $.rails.confirm(message)
+        callback = $.rails.fire(element, 'confirm:complete', [answer])
+      return answer && callback
   false

--- a/vendor/assets/javascripts/twitter/bootstrap/rails/confirm.coffee
+++ b/vendor/assets/javascripts/twitter/bootstrap/rails/confirm.coffee
@@ -9,13 +9,17 @@ $.fn.twitter_bootstrap_confirmbox =
 
 TwitterBootstrapConfirmBox = (message, element, callback) ->
   $dialog = $('
-    <div class="modal hide" id="confirmation_dialog">
-      <div class="modal-header">
-        <button type="button" class="close" data-dismiss="modal">×</button>
-        <h3>...</h3>
+    <div class="modal" id="confirmation_dialog" role="dialog">
+      <div class="modal-dialog">
+        <div class="modal-content">
+          <div class="modal-header">
+            <button type="button" class="close" data-dismiss="modal">×</button>
+            <h4 class="modal-title">...</h4>
+          </div>
+          <div class="modal-body"></div>
+          <div class="modal-footer"></div>
+        </div>
       </div>
-      <div class="modal-body"></div>
-      <div class="modal-footer"></div>
     </div>
   ')
 
@@ -23,7 +27,7 @@ TwitterBootstrapConfirmBox = (message, element, callback) ->
 
   $dialog
     .find(".modal-header")
-      .find("h3")
+      .find("h4")
         .html(element.data("confirm-title") || $.fn.twitter_bootstrap_confirmbox.defaults.title || window.top.location.origin)
       .end()
     .end()
@@ -37,7 +41,7 @@ TwitterBootstrapConfirmBox = (message, element, callback) ->
         $("<a />", {href: "#", "data-dismiss": "modal"})
           .html(element.data("confirm-cancel") || $.fn.twitter_bootstrap_confirmbox.defaults.cancel)
           .addClass($.fn.twitter_bootstrap_confirmbox.defaults.cancel_class)
-          .addClass(element.data("confirm-cancel-class"))
+          .addClass(element.data("confirm-cancel-class") || "btn-default")
           .click((event) ->
             event.preventDefault()
             $dialog.modal("hide")


### PR DESCRIPTION
If you have a confirm button on a modal, you open a new modal for the confirm action, it's not very cute and rpsec don't love it !
