### PR TITLE
avoid opening another modal when user hit enter

### DIFF
--- a/vendor/assets/javascripts/twitter/bootstrap/rails/confirm.coffee
+++ b/vendor/assets/javascripts/twitter/bootstrap/rails/confirm.coffee
@@ -81,6 +81,7 @@ TwitterBootstrapConfirmBox = (message, element, callback) ->
 
 if (typeof $().modal == 'function') # test if bootstrap is loaded
   $.rails.allowAction = (element) ->
+    $(element).blur();
     message = element.data("confirm")
     answer = false
     return true unless message


### PR DESCRIPTION
After clicking a link with data-confirm it's still have focus, making another modal appear if the user hit enter. This force the clicked link to loose focus.