### PR TITLE
Confirm dialog on enter keypress

### DIFF
--- a/vendor/assets/javascripts/twitter/bootstrap/rails/confirm.coffee
+++ b/vendor/assets/javascripts/twitter/bootstrap/rails/confirm.coffee
@@ -72,6 +72,10 @@ TwitterBootstrapConfirmBox = (message, element, callback) ->
           )
       )
     .end()
+    
+    .on('keypress', (e) ->
+      $('.modal-footer a:last').trigger('click') if e.keyCode == 13 # Enter Key Code
+    )
 
     .on("hidden", -> $(this).remove())
 


### PR DESCRIPTION
Default confirm dialogs can be confirmed with enter keypress, add a listener that trigger clicking on the submit button.