### PR TITLE
Bootstrap 4 version is stored in Tooltip.VERSION

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,10 @@ simple app that loads Bootstrap and this gem.
 
 ## Changelog
 
+### 2.0.1 (January 14, 2018)
+
+* [(eirvandelden)](https://github.com/eirvandelden) [Bootstrap 4 version is stored in Tooltip.VERSION](https://github.com/bluerail/twitter-bootstrap-rails-confirm/pull/38)
+
 ### 2.0.0 (April 26, 2018)
 
 * [(mftaff)](https://github.com/mftaff) [Convert CoffeeScript to JavaScript](https://github.com/bluerail/twitter-bootstrap-rails-confirm/pull/37)

--- a/lib/twitter-bootstrap-rails-confirm/version.rb
+++ b/lib/twitter-bootstrap-rails-confirm/version.rb
@@ -2,7 +2,7 @@ module Twitter
   module Bootstrap
     module Rails
       module Confirm
-        VERSION = "2.0.0"
+        VERSION = "2.0.1"
       end
     end
   end

--- a/vendor/assets/javascripts/twitter/bootstrap/rails/confirm.js
+++ b/vendor/assets/javascripts/twitter/bootstrap/rails/confirm.js
@@ -15,7 +15,15 @@
 
   TwitterBootstrapConfirmBox = function(message, element, callback) {
     var $dialog, bootstrap_version;
-    bootstrap_version = typeof $().emulateTransitionEnd === 'function' ? parseInt($.fn.tooltip.Constructor.VERSION[0]) : 2;
+    if (typeof $().emulateTransitionEnd === 'function') {
+      if ($.fn.tooltip.Constructor === undefined) {
+        bootstrap_version = Tooltip.VERSION[0]
+      } else {
+        bootstrap_version = $.fn.tooltip.Constructor.VERSION[0]
+      }
+    } else {
+      bootstrap_version = 2
+    }
 
     switch (bootstrap_version) {
       case 2:


### PR DESCRIPTION
and no longer in , not $.fn.tooltip.Constructor.VERSION