### PR TITLE
Fixes use of for..in to iterate over array

### DIFF
--- a/vendor/assets/javascripts/twitter/bootstrap/rails/confirm.js
+++ b/vendor/assets/javascripts/twitter/bootstrap/rails/confirm.js
@@ -47,8 +47,8 @@
     var dialog_body = $dialog.find(".modal-body");
     var paragraphs = message.toString().split(/\n/);
     dialog_body.html('');
-    for (var paragraph_index in paragraphs) {
-      $("<p></p>").appendTo(dialog_body).text(paragraphs[paragraph_index]);
+    for (var i = 0; i < paragraphs.length; i++) {
+      $("<p></p>").appendTo(dialog_body).text(paragraphs[i]);
     }
 
     var cancel_buton = $("<a />", { href: "#", "data-dismiss": "modal" });


### PR DESCRIPTION
The use of `for .. in` to iterate over an array does not work if there are extra functions defined on the prototype of array. Use a naive old school iterator instead. Could use `for .. of` if IE support is not an issue.